### PR TITLE
Improves UI with new toolbar and dark theme

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/lib/pages/drawing_page.dart
+++ b/lib/pages/drawing_page.dart
@@ -4,6 +4,7 @@ import '../models/frame_data.dart';
 import '../utils/thumbnail_rendrer.dart';
 import '../widgets/drawing_canvas.dart';
 import '../utils/tweening.dart';
+import '../widgets/second_top_toolbar.dart';
 
 class DrawingPage extends StatefulWidget {
   const DrawingPage({super.key});
@@ -121,36 +122,51 @@ class _DrawingPageState extends State<DrawingPage> {
     final currentFrame = _frames[_currentFrameIndex];
 
     return Scaffold(
+      backgroundColor: Color(0xFF111318),
       appBar: AppBar(
-        title: const Text('🎨 Animation Sketch'),
+        backgroundColor: Color(0xFF43474E),
+        title: const Text(
+          'Drawing Animation',
+          style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: Color(0xFFE1E2E9)
+          ),
+        ),
         actions: [
-          IconButton(icon: const Icon(Icons.copy), onPressed: _copyFrame),
-          IconButton(icon: const Icon(Icons.paste), onPressed: _pasteFrame),
-          IconButton(icon: const Icon(Icons.auto_fix_high), onPressed: _generateTween),
+          IconButton(icon: const Icon(Icons.copy,color: Color(0xFFE1E2E9)), onPressed: _copyFrame),
+          IconButton(icon: const Icon(Icons.paste,color: Color(0xFFE1E2E9)), onPressed: _pasteFrame),
+          IconButton(icon: const Icon(Icons.auto_fix_high,color: Color(0xFFE1E2E9)), onPressed: _generateTween),
           IconButton(
-            icon: Icon(_showOnionSkin ? Icons.layers_clear : Icons.layers),
+            icon: Icon(_showOnionSkin ? Icons.layers_clear : Icons.layers,color: Color(0xFFE1E2E9)),
             onPressed: () => setState(() => _showOnionSkin = !_showOnionSkin),
           ),
           PopupMenuButton<int>(
             initialValue: _onionSkinCount,
-            icon: const Icon(Icons.filter_frames),
+            icon: const Icon(Icons.filter_frames,color: Color(0xFFE1E2E9)),
             onSelected: (val) => setState(() => _onionSkinCount = val),
             itemBuilder: (context) => [
               for (int i = 1; i <= 5; i++) PopupMenuItem(value: i, child: Text('$i Onion Frame')),
             ],
           ),
           IconButton(
-            icon: Icon(_isPlaying ? Icons.stop : Icons.play_arrow),
+            icon: Icon(_isPlaying ? Icons.stop : Icons.play_arrow,color: Color(0xFFE1E2E9)),
             onPressed: _togglePlay,
           ),
         ],
       ),
-      body: Row(
+      body: Column(
+          children: [
+      SecondTopToolbar(), //TODO:ai biết gì đâu :v
+    // Body chính
+    Expanded(
+    child: Row(
         children: [
           if (_showFrameList)
             Container(
+              margin: const EdgeInsets.only(right: 4, top: 4),
               width: 240,
-              color: Colors.grey[100],
+              color: Color(0xFF43474E),
               child: Stack(
                 children: [
                   Padding(
@@ -231,7 +247,7 @@ class _DrawingPageState extends State<DrawingPage> {
                     top: 4,
                     right: 4,
                     child: IconButton(
-                      icon: const Icon(Icons.menu_open, size: 30),
+                      icon: const Icon(Icons.menu_open, size: 30, color: Color(0xFFE1E2E9)),
                       onPressed: () => setState(() => _showFrameList = false),
                     ),
                   ),
@@ -256,6 +272,9 @@ class _DrawingPageState extends State<DrawingPage> {
             ),
           if (_showFrameList) Expanded(child: _buildCanvas(currentFrame)),
         ],
+      ),
+    ),
+  ],
       ),
     );
   }

--- a/lib/widgets/second_top_toolbar.dart
+++ b/lib/widgets/second_top_toolbar.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+
+class SecondTopToolbar extends StatelessWidget {
+  const SecondTopToolbar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(top: 4),
+      color: Color(0xFF43474E),
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      height: 50,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            color: Color(0xFFE1E2E9),
+            onPressed: () {}, // TODO: Add settings logic
+          ),
+          IconButton(
+            icon: const Icon(Icons.save),
+            color: Color(0xFFE1E2E9),
+            onPressed: () {}, // TODO: Add save logic
+          ),
+          IconButton(
+            icon: const Icon(Icons.share),
+            color: Color(0xFFE1E2E9),
+            onPressed: () {}, // TODO: Add share logic
+          ),
+          const VerticalDivider(),
+          IconButton(
+            icon: const Icon(Icons.undo),
+            color: Color(0xFFE1E2E9),
+            onPressed: () {}, // TODO: Add share logic
+          ),
+          IconButton(
+            icon: const Icon(Icons.redo),
+            color: Color(0xFFE1E2E9),
+            onPressed: () {}, // TODO: Add redo logic
+          ),
+          const VerticalDivider(),
+          IconButton(
+            icon: const Icon(Icons.select_all),
+            color: Color(0xFFE1E2E9),
+            onPressed: () {}, // TODO: Add select_all logic
+          ),
+          const VerticalDivider(),
+          IconButton(
+            icon: const Icon(Icons.question_mark),
+            color: Color(0xFFE1E2E9),
+            onPressed: () {}, // TODO: Add logic
+          ),
+          IconButton(
+            icon: const Icon(Icons.question_mark),
+            color: Color(0xFFE1E2E9),
+            onPressed: () {}, // TODO: Add logic
+          ),
+          const VerticalDivider(),
+          IconButton(
+            icon: const Icon(Icons.question_mark),
+            color: Color(0xFFE1E2E9),
+            onPressed: () {}, // TODO: Add logic
+          ),
+          IconButton(
+            icon: const Icon(Icons.format_color_fill),
+            color: Color(0xFFE1E2E9),
+            onPressed: () {}, // TODO: Add color logic
+          ),
+          IconButton(
+            icon: const Icon(Icons.question_mark),
+            color: Color(0xFFE1E2E9),
+            onPressed: () {}, // TODO: Add logic
+          ),
+          IconButton(
+            icon: const Icon(Icons.question_mark),
+            color: Color(0xFFE1E2E9),
+            onPressed: () {}, // TODO: Add logic
+          ),
+          IconButton(
+            icon: const Icon(Icons.colorize),
+            color: Color(0xFFE1E2E9),
+            onPressed: () {}, // TODO: Add logic
+          ),
+          const VerticalDivider(),
+          IconButton(
+            icon: const Icon(Icons.square_outlined),
+            color: Color(0xFFE1E2E9),
+            onPressed: () {}, // TODO: Add logic
+          ),
+          IconButton(
+            icon: const Icon(Icons.brightness_1_outlined),
+            color: Color(0xFFE1E2E9),
+            onPressed: () {}, // TODO: Add logic
+          ),
+          IconButton(
+            icon: const Icon(Icons.change_history),
+            color: Color(0xFFE1E2E9),
+            onPressed: () {}, // TODO: Add logic
+          ),
+          const VerticalDivider(),
+          IconButton(
+            icon: const Icon(Icons.mic),
+            color: Color(0xFFE1E2E9),
+            onPressed: () {}, // TODO: Add logic
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Enhances the drawing page with a secondary top toolbar for additional functionalities and adopts a dark theme for improved aesthetics.

Adds a new `SecondTopToolbar` widget and integrates it into the `DrawingPage` layout. The toolbar includes icons for settings, save, share, undo/redo, and other drawing-related functions. Applies a dark color scheme to the app bar, background, and frame list for a more modern look.